### PR TITLE
Fixes has_answer_key not initialized

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -123,7 +123,7 @@ void FindAnswer(IntegratedCSPSolver& solver) {
 }
 
 int main() {
-    bool has_answer_key;
+    bool has_answer_key = false;
     std::vector<std::string> answer_keys;
     IntegratedCSPSolver solver;
     InputCSP(solver, has_answer_key, answer_keys);


### PR DESCRIPTION
I was unable to call FindAnswer even if there is no answer key in stdin. Then I found the variable  ``has_answer_key`` is not initialized in ``main.cpp``, line 126.

https://github.com/semiexp/csugar/blob/master/src/main.cpp#L126

After changing this line to ``bool has_answer_key = false;`` the problem seems to be solved.